### PR TITLE
[doc] Add install and build recipes for RedHat/fedora and Archlinux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,35 @@ off until after that goal is achieved.
 
 First, install a 32bit MingW-w64 GCC (with C++ support) and and a cross-compiler CMake.
 
+Choose your Linux distro, and run the respective commands to install the build dependencies and cross-compile AVS:
+
+<details><summary><em>Fedora / RedHat</em></summary>
+
+```shell
+sudo dnf install mingw32-gcc-c++ mingw32-gcc
+mkdir -p build
+cd build
+mingw32-cmake ..
+make
+```
+    
+ </details>
+
+<details><summary><em>Archlinux</em></summary>
+
+```shell
+sudo pacman -S --needed mingw-w64-gcc mingw-w64-cmake
+mkdir -p build
+cd build
+i686-w64-mingw32-cmake ..
+make
+```
+
+ </details>
+
+
+```shell
+
 ```shell
 mkdir build
 cd build

--- a/avs/vis_avs/apesdk/avstut00.cpp
+++ b/avs/vis_avs/apesdk/avstut00.cpp
@@ -49,7 +49,15 @@ class C_THISCLASS : public C_RBASE
 		virtual ~C_THISCLASS();
 
 		virtual int render(char visdata[2][2][576], int isBeat, int *framebuffer, int *fbout, int w, int h);
-		
+
+		// visdata contains 
+		// [0][L,R][...] left/right oscilloscope data with 576 samples each
+		// [1][L,R][...] left/right spectrograph data with 576 samples each	
+		// isBeat is either 0 or 1 depending whether a beat was detected
+		// *framebuffer
+		// *fbout - "frame buffer out"?
+		// width and height of framebuffer
+
 		virtual HWND conf(HINSTANCE hInstance, HWND hwndParent);
 		virtual char *get_desc();
 

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 if [ ! -d build ]; then
     (mkdir -p build \
         && cd build \
-        && i686-w64-mingw32-cmake \
+        && mingw32-cmake \
             -D CMAKE_TOOLCHAIN_FILE=../CMake-MingWcross-toolchain.txt \
             .. \
         && make

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 if [ ! -d build ]; then
     (mkdir -p build \
         && cd build \
-        && mingw32-cmake \
+        && i686-w64-mingw32-cmake \
             -D CMAKE_TOOLCHAIN_FILE=../CMake-MingWcross-toolchain.txt \
             .. \
         && make


### PR DESCRIPTION
add commandline recipes with html-details-formatting for installation and building on RedHat/Fedora and Archlinux distros.