### PR TITLE
superscope: Fix center channel generation for spectrum

### DIFF
--- a/avs/vis_avs/e_superscope.cpp
+++ b/avs/vis_avs/e_superscope.cpp
@@ -111,9 +111,19 @@ int E_SuperScope::render(char visdata[2][2][576],
     int sign_invert = this->config.audio_source ? 0 : 128;
 
     if (this->config.audio_channel == 0) {
-        for (x = 0; x < 576; x++)
-            center_channel[x] = visdata[1 - this->config.audio_source][0][x] / 2
-                                + visdata[1 - this->config.audio_source][1][x] / 2;
+        if (this->config.audio_source == 0) {
+            for (x = 0; x < 576; x++) {
+                center_channel[x] =
+                    (signed char)visdata[1 - this->config.audio_source][0][x] / 2
+                    + (signed char)visdata[1 - this->config.audio_source][1][x] / 2;
+            }
+        } else {
+            for (x = 0; x < 576; x++) {
+                center_channel[x] =
+                    (unsigned char)visdata[1 - this->config.audio_source][0][x] / 2
+                    + (unsigned char)visdata[1 - this->config.audio_source][1][x] / 2;
+            }
+        }
         audio_data = (unsigned char*)center_channel;
     } else {
         audio_data = (unsigned char*)&visdata[1 - this->config.audio_source]


### PR DESCRIPTION
# Input Left + Right
![avs_left](https://user-images.githubusercontent.com/1577132/219883632-0b5a8ebf-e072-4c8c-9b55-80177a5933c9.png) ![avs_right](https://user-images.githubusercontent.com/1577132/219883639-d32dd6c2-ac8c-41e5-8562-5f1cc118c0d5.png)

# Center Output
##  Before
![avs_center_broken](https://user-images.githubusercontent.com/1577132/219883670-9b30eee5-02a1-4274-a6ce-3c6faf921350.png)

## After
![avs_center_fixed](https://user-images.githubusercontent.com/1577132/219883679-4697c7ea-8a51-4034-801c-ac000977149f.png)

---
Created with https://github.com/hartwork/visdriver and https://github.com/KDE/spectacle :smiley: 