### PR TITLE
Get CI off of about-to-be-removed Ubuntu 20.04

### DIFF
--- a/.github/workflows/check-and-build.yml
+++ b/.github/workflows/check-and-build.yml
@@ -44,7 +44,7 @@ jobs:
 
   build-linux:
     name: Build on Ubuntu with MinGW GCC
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 


### PR DESCRIPTION
Because of https://github.com/actions/runner-images/issues/11101